### PR TITLE
Fixed return value from lambda

### DIFF
--- a/py2js/__init__.py
+++ b/py2js/__init__.py
@@ -482,7 +482,7 @@ class JS(object):
         return ", ".join([self.visit(arg) for arg in node.args])
 
     def visit_Lambda(self, node):
-        return "function(%s) {%s}" % (self.visit(node.args), self.visit(node.body))
+        return "function(%s) {return %s}" % (self.visit(node.args), self.visit(node.body))
 
     def visit_BoolOp(self, node):
         return self.get_bool_op(node).join([ "(%s)" % self.visit(val) for val in node.values ])


### PR DESCRIPTION
```python
pow2 = lambda x: x**2
```

*->*

actual:
```js
var pow2 = function(x) {Math.pow(x, 2)};
```

expected:
```js
var pow2 = function(x) {return Math.pow(x, 2)};
```